### PR TITLE
No need to access function outside the namespace

### DIFF
--- a/src/CookieHandler.php
+++ b/src/CookieHandler.php
@@ -58,7 +58,7 @@ class CookieHandler
             ? $this->security->encrypt($cookie->getJSON())
             : $cookie->getJSON();
 
-        return \setcookie(
+        return setcookie(
             $cookie->getName(),
             $value,
             $cookie->getExpires(),


### PR DESCRIPTION
Removed a slash that is not needed as setcookie() is accessible under any namespace.