### PR TITLE
Update CookieHandler.php

### DIFF
--- a/src/CookieHandler.php
+++ b/src/CookieHandler.php
@@ -30,12 +30,13 @@ class CookieHandler
      *
      * @param string $key The Encryption Key. If null, the security class won't be created
      */
-    public function __construct($key = null)
+    public function __construct(string $key = null)
     {
-        if (!empty($key)) {
+        if ($key) {
             $this->security = new SimpleSecurity($key);
             $this->key = $key;
         }
+     
     }
 
     /**


### PR DESCRIPTION
Makes sure $key is a string or else if will throw an error instead of continuing to execute the script.